### PR TITLE
Fix tool-menu not loading in Firefox

### DIFF
--- a/app/custom/templates/umap/header.html
+++ b/app/custom/templates/umap/header.html
@@ -1,5 +1,5 @@
 {% load static %}
-<!-- HOTOSM Tool Menu Web Component -->
+<!-- HOTOSM Tool Menu Web Component (@hotosm/tool-menu) -->
 <script type="importmap">
   {
     "imports": {
@@ -8,11 +8,12 @@
     }
   }
 </script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/@hotosm/tool-menu@0.2.6/dist/tool-menu.esm.js"></script>
+
 {% if AUTH_PROVIDER == 'hanko' %}
 <!-- HOTOSM Auth Web Component (@hotosm/hanko-auth) -->
 <script type="module" src="https://cdn.jsdelivr.net/npm/@hotosm/hanko-auth@0.5.2/dist/hanko-auth.esm.js"></script>
 {% endif %}
-<script type="module" src="https://cdn.jsdelivr.net/npm/@hotosm/tool-menu@0.2.6/dist/tool-menu.esm.js"></script>
 
 <!-- Matomo -->
 <script>


### PR DESCRIPTION
Move <script type="importmap"> before any <script type="module"> tags. 
Firefox strictly requires importmaps to be declared before module scripts — having hanko-auth.esm.js load first caused the importmap to be ignored, breaking the lit import resolution for tool-menu.